### PR TITLE
form 级联下拉框支持共享同一个store

### DIFF
--- a/src/form/group/select.js
+++ b/src/form/group/select.js
@@ -36,8 +36,8 @@ define('bui/form/group/select',['bui/form/group/base','bui/data'],function (requ
           store.url = url;
         }
         store = new Data.TreeStore(store);
-        _self.set('store',store);
       }
+      _self.set('store',store);
     },
     bindUI : function  () {
       var _self = this;


### PR DESCRIPTION
老代码支持这种写法，但是有bug，现在可以这样用
addType(‘name’, treeStore)
