### PR TITLE
表格数据为空的情况下，分页工具栏无法获取到记录数，显示为“共条数据”。Update toolbar.js

### DIFF
--- a/build/toolbar.js
+++ b/build/toolbar.js
@@ -481,11 +481,11 @@ define('bui/toolbar/pagingbar',['bui/toolbar/bar'],function(require) {
                 totalPage = totalPage > 0 ? totalPage : 1;
                 curPage = parseInt(start / pageSize, 10) + 1;
 
-                _self.set('start', start);
-                _self.set('end', end);
-                _self.set('totalCount', totalCount);
-                _self.set('curPage', curPage);
-                _self.set('totalPage', totalPage);
+                _self._set('start', start);
+                _self._set('end', end);
+                _self._set('totalCount', totalCount);
+                _self._set('curPage', curPage);
+                _self._set('totalPage', totalPage);
 
                 //设置按钮状态
                 _self._setAllButtonsState();


### PR DESCRIPTION
表格在没有数据的情况下，如果开启分页，会显示“共条记录”，看了源码，自定义属性totalCount的值为0，和设置默认值重复，无法通过__attrVals枚举，导致输出的时候获取不到记录数，使用_set可解决。
